### PR TITLE
fix: pwa name

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,8 +13,8 @@ export default defineConfig({
       },
       injectRegister: "auto",
       manifest: {
-        name: "vite-react-ts-100",
-        short_name: "vite-react-ts-100",
+        name: "EB Doceria Gourmet",
+        short_name: "EB Doceria Gourmet",
         start_url: "/",
         display: "standalone",
         background_color: "#ffffff",


### PR DESCRIPTION
Name and title wrongly set in `vite.config.ts`